### PR TITLE
[FIX] Insert return `-1` as lastID

### DIFF
--- a/src/DB.php
+++ b/src/DB.php
@@ -7,7 +7,6 @@
  */
 namespace Wepesi\App;
 use Exception;
-use PDO;
 use Wepesi\App\Traits\BuildQuery;
 
 class DB
@@ -18,13 +17,13 @@ class DB
     private ?string $_error;
     private array $_results;
     private  int $_lastID;
-    private PDO $pdo;
+    private \PDO $pdo;
     private string $_action="";
     private int $_count;
     private array $option=[
-        PDO::MYSQL_ATTR_INIT_COMMAND=>"SET NAMES utf8",
-        PDO::ATTR_EMULATE_PREPARES=>false,
-        PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION
+        \PDO::MYSQL_ATTR_INIT_COMMAND=>"SET NAMES utf8",
+        \PDO::ATTR_EMULATE_PREPARES=>false,
+        \PDO::ATTR_ERRMODE=>\PDO::ERRMODE_EXCEPTION
     ]  ;
     use BuildQuery;
     private function __construct(string $host="",string $db_name="",string $user_name="",string $password="")
@@ -35,7 +34,7 @@ class DB
             $this->_lastID = -1;
             $this->_count = 0;
             //
-            $this->pdo = new PDO("mysql:host=" . $host . ";dbname=" . $db_name.";charset=utf8mb4", $user_name,$password,$this->option);
+            $this->pdo = new \PDO("mysql:host=" . $host . ";dbname=" . $db_name.";charset=utf8mb4", $user_name,$password,$this->option);
         } catch (\PDOException $ex) {
             echo $ex->getMessage();
             die();
@@ -143,7 +142,7 @@ class DB
         $this->_results = $q['result'];
         $this->_count = $q['count'];
         $this->_error = $q['error'];
-        $this->_lastID = $q['lastID'];
+        $this->_lastID = $q['lastID']??-1;
 
         return $this;
     }
@@ -154,7 +153,7 @@ class DB
     function lastId(): int
     {
         if (isset($this->query_transaction) && method_exists($this->query_transaction, 'lastId')) {
-            $this->_count = $this->query_transaction->lastId();
+            $this->_lastID = $this->query_transaction->lastId();
         }
         return $this->_lastID;
     }

--- a/src/DB_Insert.php
+++ b/src/DB_Insert.php
@@ -7,7 +7,9 @@
  */
 namespace Wepesi\App;
 
-class DB_Insert 
+use Wepesi\App\Traits\BuildQuery;
+
+class DB_Insert
 {
     private string $table;
     private \PDO $pdo;
@@ -69,8 +71,8 @@ class DB_Insert
     {
         $q = $this->executeQuery($this->pdo, $sql, $params);
         $this->_results = $q['result'];
-        $this->_error = $q['error'];
         $this->lastID = $q['lastID']??0;
+        $this->_error = $q['error'];
     }
 
     /**

--- a/src/DB_Select.php
+++ b/src/DB_Select.php
@@ -14,7 +14,7 @@ class DB_Select
     private  ?string $table, $action,$_error,$_dsc,$_asc,$orderBy,$groupBY;
     private  array $_where,  $_fields;
     private ?int $_limit,  $_offset;
-    private array $_join_comparison_sign=["=",">","<","!=","<>"];
+    private array $_join_comparison_sign;
     use BuildQuery;
 
     /**
@@ -30,18 +30,18 @@ class DB_Select
         $this->action = $action;
         $this->_dsc = $this->_asc=null;
         $this->_where = $this->_fields =[];
-        $this->_error =null;
-        $this->orderBy = $this->groupBY =null;
-        $this->_limit = $this->_offset=null;
+        $this->_error = null;
+        $this->orderBy = $this->groupBY = null;
+        $this->_limit = $this->_offset = null;
+        $this->_join_comparison_sign = ['=', '>', '<', '!=', '<>'];
     }
 
     /**
-     *
      * @param array $params
      * @return $this
-     * @throws Exception
+     * @throws \Exception
      */
-    function where(array $params = [])
+    function where(array $params = []): DB_Select
     {
         if (count($params)) {
             // $params = [];

--- a/src/Traits/BuildQuery.php
+++ b/src/Traits/BuildQuery.php
@@ -16,7 +16,7 @@ trait BuildQuery
                 'result' => [],
                 'lastID' => -1,
                 'count' => null,
-                'error' => null,
+                'error' => "",
             ];
             $query = $pdo->prepare($sql);
             $x = 1;
@@ -26,15 +26,18 @@ trait BuildQuery
                     $x++;
                 }
             }
-            $query->execute();
+            $query_result = $query->execute();
 
-            if (strchr(strtolower($sql), 'update') || strchr(strtolower($sql), 'select')) {
-                $data_result['result'] = $query->fetchAll(\PDO::FETCH_OBJ);
-                $data_result['count'] = $query->rowCount();
-            } else if (strchr(strtolower($sql), 'insert into')) {
-                $data_result['lastID'] = $pdo->lastInsertId();
-            } else if (strchr(strtolower($sql), 'delete')) {
-                $data_result['result'] = ['delete' => true];
+            if($query_result){
+                $data_result['result'] = ['query_result' => true];
+                if (strchr(strtolower($sql), 'update') || strchr(strtolower($sql), 'select')) {
+                    $data_result['result'] = $query->fetchAll(\PDO::FETCH_OBJ);
+                    $data_result['count'] = $query->rowCount();
+                } else if (strchr(strtolower($sql), 'insert into')) {
+                    $data_result['lastID'] = $pdo->lastInsertId();
+                } else if (strchr(strtolower($sql), 'delete')) {
+                    $data_result['result'] = ['delete' => true];
+                }
             }
             return $data_result;
         } catch (\PDOException $ex) {

--- a/test/index.php
+++ b/test/index.php
@@ -8,8 +8,8 @@ $config=[
     "password"=>""
 ];
 $db = DB::getInstance($config);
-// include("./test/insert.php");
-include("./test/select.php");
+ include("./test/insert.php");
+//include("./test/select.php");
 // include("./test/delete.php");
 // include("./test/query.php");
 // include("./test/update.php");

--- a/test/insert.php
+++ b/test/insert.php
@@ -10,7 +10,8 @@ try {
     if($db->error()){
         throw new \Exception($db->error());
     }
-    var_dump(["last insert ID : "=>$db->lastId()]);
+    $field["id"] = $db->lastId();
+    var_dump($field);
 } catch (Exception $e) {
     var_dump($e->getMessage());
 }


### PR DESCRIPTION
When insert a new record, and we want to get the last id from `lastid` it return `-1` instea of returning the id of the las record.
closes #21 