### PR TITLE
[FIX] Problem parsing string to array

### DIFF
--- a/src/DB_Select.php
+++ b/src/DB_Select.php
@@ -39,7 +39,8 @@ class DB_Select
         $this->_pdo = $pdo;
         $this->action = $action;
         $this->_dsc = $this->_asc = "";
-        $this->_where = $this->_fields =[];
+        $this->_where =[];
+        $this->_fields =['keys' => '*'];
         $this->_error = null;
         $this->orderBy = $this->groupBY = null;
         $this->_limit = $this->_offset = null;
@@ -124,8 +125,6 @@ class DB_Select
                 'keys' => '' . implode(',', $keys) . '',
                 'values' => $values
             ];
-        } else {
-            $this->_fields = '*';
         }
         return $this;
     }


### PR DESCRIPTION
There is a problem while trying to get data from table with a empy filed array it generate error parsing, cause the field param as been declare as array then it can not take string value.
closes #32 